### PR TITLE
Python3 compability

### DIFF
--- a/botan.py
+++ b/botan.py
@@ -25,5 +25,5 @@ def track(token, uid, message, name='Message'):
         return False
     except requests.exceptions.RequestException as e:
         # catastrophic error
-        print e
+        print(e)
         return False


### PR DESCRIPTION
With `print e` botan will fail when run with Python 3.x.
Changed to `print(e)`