### PR TITLE
Node.js: rewrote with native lib

### DIFF
--- a/nodejs/botan.js
+++ b/nodejs/botan.js
@@ -1,36 +1,54 @@
-var request = require('request');
+'use strict';
 
-var BOTAN_URL = 'https://api.botan.io/track';
+var https = require('https');
+var qs = require('querystring');
 var DEFAULT_NAME = 'Message';
 
-module.exports = function (apikey) {
-    var token = apikey;
-    return {
-        /**
-         * @param {Object} message
-         * @param {String} [name='Message']
-         * @param {Function} [callback]
-         */
-        track: function (message, name, callback) {
-            if (typeof name === 'function') {
-                callback = name;
-                name = DEFAULT_NAME;
-            }
+module.exports = function(token) {
+  return {
+    /**
+     * @param {Object} message
+     * @param {String} [name='Message']
+     * @param {Function} [cb]
+     */
+    track: function(message, name, cb) {
+      if (typeof name === 'function') {
+        cb = name;
+        name = DEFAULT_NAME;
+      }
 
-            request({
-                method: 'POST',
-                url: BOTAN_URL,
-                qs: {
-                    token: token,
-                    uid: message.from.id,
-                    name: name || DEFAULT_NAME
-                },
-                json: message
-            }, function (error, response, body) {
-                if (callback) {
-                    callback(error, response, body);
-                }
-            });
+      var options = {
+        hostname: 'api.botan.io',
+        path: '/track?' + qs.stringify({
+          token: token,
+          uid: message.from.id,
+          name: name || DEFAULT_NAME
+        }),
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
         }
-    };
+      };
+
+      https.request(options, function(res) {
+        var data = '';
+
+        res.on('data', function(chunk) {
+          data += chunk;
+        });
+
+        res.on('end', function() {
+          if (cb && typeof cb === 'function') {
+            cb(null, res, JSON.parse(data));
+          }
+        });
+      })
+      .on('error', function(err) {
+        if (cb && typeof cb === 'function') {
+          cb(err);
+        }
+      })
+      .end(JSON.stringify(message));
+    }
+  };
 };

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -16,8 +16,5 @@
   "bugs": {
     "url": "https://github.com/botanio/sdk/issues"
   },
-  "homepage": "https://github.com/botanio/sdk#readme",
-  "dependencies": {
-    "request": "2.57.0"
-  }
+  "homepage": "https://github.com/botanio/sdk#readme"
 }


### PR DESCRIPTION
This is not a good practice to use the complex and heavy `request` (2.8 MB) for a simple request.

Rewrote with native `https` lib.