### PR TITLE
added tracking support for inline requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #Botan SDK
 
+[![Join the chat at https://gitter.im/moldabekov/sdk](https://badges.gitter.im/moldabekov/sdk.svg)](https://gitter.im/moldabekov/sdk?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 [Botan](http://botan.io) is a telegram bot analytics system based on [Yandex.Appmetrica](http://appmetrica.yandex.com/).
 In this document you can find how to setup Yandex.Appmetrica account, as well as examples of Botan SDK usage.
 

--- a/botan.py
+++ b/botan.py
@@ -15,12 +15,35 @@ TRACK_URL = 'https://api.botan.io/track'
 SHORTENER_URL = 'https://api.botan.io/s/'
 
 
-def track(token, uid, message, name='Message'):
+def make_json(message, inline=False):
+    """
+        JSON serialize for track() method
+        :param is_inline:
+        :param message:
+        :type message: telegram message object
+        :type is_inline: bool
+        :return: json
+    """
+    data = {}
+    data['from'] = {}
+    data['from']['id'] = message.from_user.id
+    if message.from_user.username is not None:
+            data['from']['username'] = message.from_user.username
+    if inline is False:
+        data['message_id'] = message.message_id
+        data['chat'] = {}
+        data['chat']['id'] = message.chat.id
+    else:
+        data['message_id'] = message.id
+    return data
+
+
+def track(token, uid, message, name='Message', inline=False):
     try:
         r = requests.post(
             TRACK_URL,
             params={"token": token, "uid": uid, "name": name},
-            data=json.dumps(message),
+            data=json.dumps(make_json(message, inline)),
             headers={'Content-type': 'application/json'},
         )
         return r.json()


### PR DESCRIPTION
I found that while using `pytelegrambotapi` you can't use `botan`, because `json.dumps` fails on processing `message` object that comes from Telegram. Also I've noticed that Telegram allows you to set full set of UTF-8 to `last_name` and `first_name`, which leads to exception in `json.dumps`.

I made a small change to `botan.py`:

* Added `make_json` method, which fetches some values, such as `username`, `chat.id`, `message_id` from `message` object, which is enough to collect analytics from TG bots.
* **Added method to track inline requests.**


*If you have comments, please contact with me for further steps.
Kind regards, Margulan.*